### PR TITLE
add hints on how to search wikidata pages

### DIFF
--- a/wikiblame_inc/en.php
+++ b/wikiblame_inc/en.php
@@ -34,9 +34,9 @@ $messages['December'] = 'December';
 //Form elements
 $messages['ui_lang'] = 'Display language';
 $messages['lang'] = 'Language';
-$messages['lang_example'] = 'en, commons, …';
+$messages['lang_example'] = 'en, commons, www, …';
 $messages['project'] = 'Project';
-$messages['project_example'] = 'wikipedia, wikisource, wikimedia, …';
+$messages['project_example'] = 'wikipedia, wikisource, wikimedia, wikidata, …';
 $messages['article'] = 'Page';
 $messages['needle'] = 'Search for';
 $messages['skipversions'] = 'Always skip x versions';


### PR DESCRIPTION
WikiBlame doesn't work for Wikidata item pages, but there are many regular pages on Wikidata that can be searched with this tool.

I was not sure how to do it, though, and had to use trial and error until I succeeded. In particular, the main hiccup was that if the user leaves the domain fields empty, the first field defaults to 'en', and the second one to 'wikipedia'. As a workaround for that, 'www' _does_ work as a pseudo second-level domain, for websites that don't really have one, like wikidata.org.

Hopefully these hints will help others with similar searches :)